### PR TITLE
Use default cli.output service to be compatible with behat 3.1.0

### DIFF
--- a/spec/Cjm/Behat/StepThroughExtension/Pauser/CliPauserSpec.php
+++ b/spec/Cjm/Behat/StepThroughExtension/Pauser/CliPauserSpec.php
@@ -2,9 +2,9 @@
 
 namespace spec\Cjm\Behat\StepThroughExtension\Pauser;
 
-use Behat\Testwork\Output\Printer\OutputPrinter;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class CliPauserSpec extends ObjectBehavior
 {
@@ -13,7 +13,7 @@ class CliPauserSpec extends ObjectBehavior
      */
     private $inputStream;
 
-    function let(OutputPrinter $output)
+    function let(OutputInterface $output)
     {
         $this->inputStream = fopen('php://memory', 'r+', false);
         $this->beConstructedWith($output, $this->inputStream);
@@ -24,14 +24,14 @@ class CliPauserSpec extends ObjectBehavior
         $this->shouldHaveType('Cjm\Behat\StepThroughExtension\Pauser\Pauser');
     }
 
-    function it_does_not_show_a_message_if_it_has_not_been_activated(OutputPrinter $output)
+    function it_does_not_show_a_message_if_it_has_not_been_activated(OutputInterface $output)
     {
         $this->pause('step name');
 
         $output->write(Argument::cetera())->shouldNotHaveBeenCalled();
     }
 
-    function it_shows_message_when_pause_is_called(OutputPrinter $output)
+    function it_shows_message_when_pause_is_called(OutputInterface $output)
     {
         fputs($this->inputStream, "Y\n");
         rewind($this->inputStream);

--- a/src/Cjm/Behat/StepThroughExtension/Pauser/CliPauser.php
+++ b/src/Cjm/Behat/StepThroughExtension/Pauser/CliPauser.php
@@ -2,12 +2,12 @@
 
 namespace Cjm\Behat\StepThroughExtension\Pauser;
 
-use Behat\Testwork\Output\Printer\OutputPrinter;
+use Symfony\Component\Console\Output\OutputInterface;
 
 final class CliPauser implements Pauser
 {
     /**
-     * @var OutputPrinter
+     * @var OutputInterface
      */
     private $output;
 
@@ -21,7 +21,7 @@ final class CliPauser implements Pauser
      */
     private $isActive = false;
 
-    public function __construct(OutputPrinter $output, $inputStream = null)
+    public function __construct(OutputInterface $output, $inputStream = null)
     {
         $this->output = $output;
         $this->inputStream = $inputStream ?: STDIN;

--- a/src/Cjm/Behat/StepThroughExtension/ServiceContainer/StepThroughExtension.php
+++ b/src/Cjm/Behat/StepThroughExtension/ServiceContainer/StepThroughExtension.php
@@ -14,6 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
 final class StepThroughExtension implements Extension
 {
     const PAUSER_ID = 'stepthroughextension.pauser';
+    const DEFAULT_BEHAT_OUTPUT_PRINTER_ID = 'cli.output';
 
     /**
      * Returns the extension config key.
@@ -66,9 +67,9 @@ final class StepThroughExtension implements Extension
     {
         $definition = new Definition(
             'Cjm\Behat\StepThroughExtension\Pauser\CliPauser',
-             array(new Definition('Behat\Behat\Output\Printer\ConsoleOutputPrinter'))
+            array(new Reference(self::DEFAULT_BEHAT_OUTPUT_PRINTER_ID))
         );
-        $container->setDefinition(self::PAUSER_ID , $definition);
+        $container->setDefinition(self::PAUSER_ID, $definition);
     }
 
     /**
@@ -89,9 +90,10 @@ final class StepThroughExtension implements Extension
      */
     private function loadListener(ContainerBuilder $container)
     {
-        $definition = new Definition('Cjm\Behat\StepThroughExtension\Listener\PausingListener', array(
-            new Reference(self::PAUSER_ID)
-        ));
+        $definition = new Definition(
+            'Cjm\Behat\StepThroughExtension\Listener\PausingListener',
+            array(new Reference(self::PAUSER_ID))
+        );
         $definition->addTag(EventDispatcherExtension::SUBSCRIBER_TAG, array('priority' => 0));
         $container->setDefinition(EventDispatcherExtension::SUBSCRIBER_TAG . '.stepthrough.pausing', $definition);
     }


### PR DESCRIPTION
This PR should fixt #3 issue. The cli.output service is available in previous behat versions as well, so it shouldn't break the BC of this extension.