### PR TITLE
Fix StepThroughController priority value

### DIFF
--- a/src/Cjm/Behat/StepThroughExtension/ServiceContainer/StepThroughExtension.php
+++ b/src/Cjm/Behat/StepThroughExtension/ServiceContainer/StepThroughExtension.php
@@ -81,7 +81,7 @@ final class StepThroughExtension implements Extension
             'Cjm\Behat\StepThroughExtension\Cli\StepThroughController',
             array(new Reference(self::PAUSER_ID))
         );
-        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 0));
+        $definition->addTag(CliExtension::CONTROLLER_TAG, array('priority' => 1));
         $container->setDefinition(CliExtension::CONTROLLER_TAG . '.stepthrough', $definition);
     }
 


### PR DESCRIPTION
I have tried to use the StepThrough extension here:

https://github.com/tkotosz/behat-test-project-with-chrome

but when I run `bin/behat --step-through` it doesn't stop after the step. But it seems if I change the StepThroughController's priority to 1 instead of 0 then it is working properly.

I am not sure about the source of the issue (I might be a bug in the behat package) but at least this small fix solves the issue.
